### PR TITLE
Lecture 11 - Notifications & Screen Rotation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'com.google.android.gms:play-services-location:17.1.0'
+    implementation 'androidx.core:core-ktx:1.3.2'
 
     implementation platform('com.google.firebase:firebase-bom:26.5.0')
     implementation 'com.google.firebase:firebase-auth-ktx'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,8 @@
         -->
         <activity
             android:name=".MapsActivity"
+            android:parentActivityName=".MainActivity"
+            android:screenOrientation="portrait"
             android:label="@string/title_activity_maps" />
 
         <activity android:name=".MainActivity">
@@ -37,7 +39,8 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".TweetsActivity" />
+        <activity android:name=".TweetsActivity"
+            android:parentActivityName=".MapsActivity" />
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="@string/google_maps_key" />


### PR DESCRIPTION
## Summary
Allows the **same** list of Tweets to be used even if the user rotates their device screen. Otherwise, the app has to make two calls (OAuth + Search Tweets) every time the user rotates their device.

Still a minor bug where the Add Tweet button & EditText re-appear post-rotation, but that can be easily fixed.

Upon new user Sign Up - we display a notification welcoming them to the app.
- Tapping the notification simply opens the app (`MainActivity`). If the app is already open, the activity is brought to the foreground.
- There is also an included button `Go To Virginia` which brings the user directly to the 3rd screen in the flow, while setting up the Maps & Main activities behind it.

<img width="487" alt="Screen Shot 2020-11-22 at 18 10 27" src="https://user-images.githubusercontent.com/5898509/99919872-0d2fb100-2cee-11eb-9b15-65e9e100ac2c.png">

<img width="871" alt="Screen Shot 2020-11-22 at 18 10 35" src="https://user-images.githubusercontent.com/5898509/99919874-0e60de00-2cee-11eb-8a84-721ddb6e1db9.png">

<img width="350" alt="Screen Shot 2020-11-22 at 18 09 14" src="https://user-images.githubusercontent.com/5898509/99919988-bd051e80-2cee-11eb-9a3d-6ebb9ca02cbc.png">